### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -2,6 +2,9 @@ name: Pylint
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/hjy03651/discord_bot_toko/security/code-scanning/1](https://github.com/hjy03651/discord_bot_toko/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow. Since the workflow only needs to read the repository contents to run Pylint, we will set `contents: read` as the permission. This ensures that the workflow has the least privilege required to function correctly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
